### PR TITLE
Add PIN_OIDC_USER_TO_OWN_DOMAIN Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ services:
       AUTH_OIDC_CLIENT_ID: ''
       # OIDC client secret provided by oauth provider
       AUTH_OIDC_CLIENT_SECRET: ''
+      # In campus environments with multiple organizations sharing a single UniFi Controller instance, it may be desirable to limit voucher administrators to managing only vouchers associated with their own organization.
+      # This restriction is based on the domain part of the administrator's email address.
+      # When enabled, the system automatically assigns the administrator’s email domain as a note to each created voucher.
+      # The voucher will contain both the email domain and any user-provided note.
+      # Vouchers without a domain note will be hidden from all users.
+      PIN_OIDC_USER_TO_OWN_DOMAIN: 'false'
       # Disables the login/authentication for the portal and API
       AUTH_DISABLE: 'false'
       # Voucher Types, format: expiration in minutes (required),single-use or multi-use vouchers value - '0' is for multi-use (unlimited) - '1' is for single-use - 'N' is for multi-use (Nx) (optional),upload speed limit in kbps (optional),download speed limit in kbps (optional),data transfer limit in MB (optional)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       AUTH_OIDC_APP_BASE_URL: ''
       AUTH_OIDC_CLIENT_ID: ''
       AUTH_OIDC_CLIENT_SECRET: ''
+      PIN_OIDC_USER_TO_OWN_DOMAIN: 'false'
       AUTH_DISABLE: 'false'
       VOUCHER_TYPES: '480,1,,,;'
       VOUCHER_CUSTOM: 'true'

--- a/modules/variables.js
+++ b/modules/variables.js
@@ -31,6 +31,7 @@ module.exports = {
     authOidcAppBaseUrl: config('auth_oidc_app_base_url') || process.env.AUTH_OIDC_APP_BASE_URL || '',
     authOidcClientId: config('auth_oidc_client_id') || process.env.AUTH_OIDC_CLIENT_ID || '',
     authOidcClientSecret: config('auth_oidc_client_secret') || process.env.AUTH_OIDC_CLIENT_SECRET || '',
+    pinOidcUserToOwnDomain: config('pin_oidc_user_to_own_domain') !== null ? config('pin_oidc_user_to_own_domain') : (process.env.PIN_OIDC_USER_TO_OWN_DOMAIN === 'true') || false,
     authDisabled: config('auth_disable') || (process.env.AUTH_DISABLE === 'true') || false,
     printers: config('printers') || process.env.PRINTERS || '',
     smtpFrom: config('smtp_from') || process.env.SMTP_FROM || '',

--- a/server.js
+++ b/server.js
@@ -571,7 +571,6 @@ if(variables.serviceWeb) {
 
         const user = req.oidc ? await req.oidc.fetchUserInfo() : { email: 'admin' };
 
-        // --- NEU: Filter nach Domain, wenn aktiviert ---
         let filteredVouchers = cache.vouchers;
         if (
             variables.pinOidcUserToOwnDomain &&
@@ -589,7 +588,6 @@ if(variables.serviceWeb) {
                 }
             });
         }
-        // --- ENDE NEU ---
 
         res.render('voucher', {
             baseUrl: req.headers['x-ingress-path'] ? req.headers['x-ingress-path'] : '',

--- a/server.js
+++ b/server.js
@@ -342,7 +342,6 @@ if(variables.serviceWeb) {
             }
         }
 
-        // --- Description und Domain kombinieren, wenn aktiviert ---
         let voucherNote = null;
         if (variables.pinOidcUserToOwnDomain && req.oidc) {
             try {
@@ -356,12 +355,11 @@ if(variables.serviceWeb) {
                     }
                 }
             } catch (e) {
-                // Fehler ignorieren, falls Userinfo nicht geladen werden kann
+                // Ignore errors, if Userinfo can not be loaded
             }
         } else {
             voucherNote = req.body['voucher-note'] !== '' ? req.body['voucher-note'] : null;
         }
-        // --- ENDE ---
 
         // Create voucher code
         const voucherCode = await unifi.create(

--- a/template/components/details.ejs
+++ b/template/components/details.ejs
@@ -45,7 +45,14 @@
                                             </div>
                                             <div class="py-2 grid grid-cols-3 gap-4 px-0">
                                                 <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Notes</dt>
-                                                <dd class="text-sm leading-6 text-gray-600 dark:text-gray-400 col-span-2 mt-0"><%= voucher.note ? voucher.note : '-' %></dd>
+                                                <dd class="text-sm leading-6 text-gray-600 dark:text-gray-400 col-span-2 mt-0">
+                                                    <% if (voucher.note && voucher.note.includes('|||')) { %>
+                                                        <strong>Description:</strong> <%= voucher.note.split('|||')[0] %><br/>
+                                                        <strong>Domain:</strong> <%= voucher.note.split('|||')[1] %>
+                                                    <% } else { %>
+                                                        <%= voucher.note ? voucher.note : '-' %>
+                                                    <% } %>
+                                                </dd>
                                             </div>
                                             <div class="py-2 grid grid-cols-3 gap-4 px-0">
                                                 <dt class="text-sm font-medium leading-6 text-gray-900 dark:text-white">Type</dt>

--- a/template/voucher.ejs
+++ b/template/voucher.ejs
@@ -167,9 +167,18 @@
                                                 <% } %>
                                             <% } %>
                                             <% if (voucher.note) { %>
-                                                <div class="hidden sm:block rounded-md flex-none py-1 px-2 text-xs font-medium ring-1 ring-inset bg-gray-50 text-gray-800 ring-gray-600/20 dark:text-gray-400 dark:bg-gray-400/10 dark:ring-gray-400/20">
-                                                    <%= voucher.note %>
-                                                </div>
+                                                <% if (voucher.note.includes('|||')) { %>
+                                                    <div class="hidden sm:block rounded-md flex-none py-1 px-2 text-xs font-medium ring-1 ring-inset bg-gray-50 text-gray-800 ring-gray-600/20 dark:text-gray-400 dark:bg-gray-400/10 dark:ring-gray-400/20">
+                                                        <%= voucher.note.split('|||')[0] %>
+                                                    </div>
+                                                    <div class="hidden sm:block rounded-md flex-none py-1 px-2 text-xs font-medium ring-1 ring-inset bg-gray-50 text-gray-800 ring-gray-600/20 dark:text-gray-400 dark:bg-gray-400/10 dark:ring-gray-400/20">
+                                                        <%= voucher.note.split('|||')[1] %>
+                                                    </div>
+                                                <% } else { %>
+                                                    <div class="hidden sm:block rounded-md flex-none py-1 px-2 text-xs font-medium ring-1 ring-inset bg-gray-50 text-gray-800 ring-gray-600/20 dark:text-gray-400 dark:bg-gray-400/10 dark:ring-gray-400/20">
+                                                        <%= voucher.note %>
+                                                    </div>
+                                                <% } %>
                                             <% } %>
                                         </div>
                                     </h2>


### PR DESCRIPTION
This pull request introduces the `PIN_OIDC_USER_TO_OWN_DOMAIN` feature, which restricts voucher visibility and assignment based on the authenticated OIDC user's email domain. When enabled, users can only see and manage vouchers associated with their own domain.

---

### Key Changes

- **Voucher Creation:**  
  When a voucher is created and the feature is enabled, the user's email domain (from OIDC) is appended to the voucher note, separated by `|||`. If a note is already provided, it is combined with the domain.
- **Voucher Filtering:**  
  On the voucher overview page, if the feature is enabled, only vouchers with a note matching the user's domain (either as the whole note or after the `|||` separator) are shown.
- **Domain Extraction:**  
  The domain is extracted from the authenticated user's email address via OIDC.
- **Backward Compatibility:**  
  If the feature is disabled, the application behaves as before, showing all vouchers.

---

### Motivation

This feature is intended for multi-tenant environments where users from different organizations should only access vouchers relevant to their own domain, improving security and data separation.

---

### Implementation Details

- The logic for combining the note and domain is in the `/voucher` POST route.
- The filtering logic is in the `/vouchers` GET route.
- The feature is controlled by the `PIN_OIDC_USER_TO_OWN_DOMAIN` variable.

---

### Testing

- Verified that users only see vouchers for their domain when the feature is enabled.
- Confirmed that voucher creation correctly appends the domain.
- Ensured that disabling the feature restores the previous behavior.

---