### PR TITLE
Accept optional note in POST /api/voucher and include note in GET /api/vouchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ the different endpoints available in the API:
           {
             "id": "67bded6766f89f2a7ba6731f",
             "code": "15695-53133",
+            "note": "Test",
             "type": "multi",
             "duration": 60,
             "data_limit": "200",
@@ -417,6 +418,7 @@ the different endpoints available in the API:
           {
             "id": "67bdecd166f89f2a7ba67317",
             "code": "03004-59449",
+            "note": null,
             "type": "single",
             "duration": 480,
             "data_limit": null,
@@ -444,6 +446,15 @@ the different endpoints available in the API:
         ```json
         {
           "type": "480,0,,,"
+        }
+        ```
+
+      - Generate Voucher and Provide note:
+
+        ```json
+        {
+          "type": "480,0,,,",
+          "note": "This is a note"
         }
         ```
 


### PR DESCRIPTION
# What changed

- **POST /api/voucher**
    - Accepts an optional `note` (must be a string). If provided:
    - sanitized (internal separators ``||;;||`` removed),
    - trimmed and limited to 255 characters,
    - stored using the existing internal notes format: `<note>||;;||api||;;||local||;;||` (passed as the voucher `name` to UniFi via `unifi.create`).
    - If `note` is omitted, behavior remains unchanged.
    - If `note` is present but not a string, the endpoint returns `400`.

- **GET /api/vouchers**
    - Each returned voucher object now includes `note`, parsed from the voucher `name` using `utils/notes` (string or `null`).