### PR TITLE
Correct year calculation in time.js

### DIFF
--- a/utils/time.js
+++ b/utils/time.js
@@ -25,5 +25,11 @@ module.exports = (minutes, language = 'en') => {
     }
 
     const days = hours / 24;
+
+    if (days < 365)
+    return `${days} ${(days > 1) ? t('days') : t('day')}`;
+
+
+    const years = days / 365;
     return `${days} ${(days > 1) ? t('days') : t('day')}`;
 }


### PR DESCRIPTION
Fix the logic to return years correctly based on days.

completely fucked up my last pull request, sorry for the spam